### PR TITLE
Modify the README to avoid issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Route::prefix('/debug')->group(function () {
 
 #### Sharing it in your views
 
-To have a `$twillGoogleRecaptcha` shared on your views, you can call this helper on your `AppServiceProvider`: 
+To have a `$twillGoogleRecaptcha` shared on your views, you can call this helper on the `boot()` method of your `AppServiceProvider`: 
 
 ``` php
 \A17\TwillGoogleRecaptcha\Services\Helpers::viewShare()


### PR DESCRIPTION
Just added the mention of the boot method inside the readme for the \A17\TwillGoogleRecaptcha\Services\Helpers::viewShare() helper